### PR TITLE
Add naive Union implementation using existing CutOut method

### DIFF
--- a/unity/.gitignore
+++ b/unity/.gitignore
@@ -68,3 +68,6 @@ crashlytics-build.properties
 
 
 # End of https://www.gitignore.io/api/unity
+
+.idea
+JetBrains.Rider.Unity.Editor.Plugin.Repacked.dll

--- a/unity/Assets/Plugins.meta
+++ b/unity/Assets/Plugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6bd5c61d5104d8c4bbbb1df1471e7606
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/Assets/Plugins/Editor.meta
+++ b/unity/Assets/Plugins/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f1f9a730db9f13c479b7ea3794ca3b8e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/Assets/Scripts/ArtGallery/Model/ArtGallerySolution.cs
+++ b/unity/Assets/Scripts/ArtGallery/Model/ArtGallerySolution.cs
@@ -4,7 +4,6 @@
     using System.Linq;
     using UnityEngine;
     using Util.Algorithms.Polygon;
-    using Util.Geometry.Polygon;
 
     /// <summary>
     /// Stores a list of lighthouses and can calculate their combined visibility area.
@@ -24,20 +23,7 @@
         {
             get
             {
-                if (Count <= 0) return 0f;
-
-                // create multi polygon of visibility area
-                var visiblePolygon = new MultiPolygon2D(m_lighthouses[0].VisionPoly);
-
-                // add visibility polygons, cutting out the overlap
-                foreach (ArtGalleryLightHouse lighthouse in m_lighthouses.Skip(1))
-                {
-                    visiblePolygon = Clipper.CutOut(visiblePolygon, lighthouse.VisionPoly);
-                    visiblePolygon.AddPolygon(lighthouse.VisionPoly);
-                }
-
-                // return total area
-                return visiblePolygon.Area;
+                return m_union.Union(m_lighthouses.Select(x => x.VisionPoly).ToList()).Area;
             }
         }
 
@@ -47,10 +33,14 @@
         // stores lighthouse objects for easy destroyal
         private List<GameObject> m_objects;
 
+        // stores the union algorithm to use for calculating the total visible area
+        private IUnion m_union;
+
         public ArtGallerySolution()
         {
             m_objects = new List<GameObject>();
             m_lighthouses = new List<ArtGalleryLightHouse>();
+            m_union = new UnionNaive();
         }
 
         /// <summary>

--- a/unity/Assets/Scripts/Editor/Tests/Algorithms/Polygon/IUnionTests.cs
+++ b/unity/Assets/Scripts/Editor/Tests/Algorithms/Polygon/IUnionTests.cs
@@ -66,57 +66,57 @@
         [Test]
         public void UnionTest1()
         {
-            var cutout = m_union.Union(new List<Polygon2D> {m_verticalRect, m_horizontalRect});
-            Assert.AreEqual(2f, cutout.Area, MathUtil.EPS);
+            var union = m_union.Union(new List<Polygon2D> {m_verticalRect, m_horizontalRect});
+            Assert.AreEqual(10f, union.Area, MathUtil.EPS);
         }
 
         [Test]
         public void UnionTest2()
         {
-            var cutout = m_union.Union(new List<Polygon2D> {m_horizontalRect, m_verticalRect});
-            Assert.AreEqual(6f, cutout.Area, MathUtil.EPS);
+            var union = m_union.Union(new List<Polygon2D> {m_horizontalRect, m_verticalRect});
+            Assert.AreEqual(10f, union.Area, MathUtil.EPS);
         }
 
         [Test]
         public void UnionRectFromSquareCollinearTest1()
         {
             var remainder = m_union.Union(new List<Polygon2D> {m_unitSquare, m_2by1rect});
-            Assert.AreEqual(0f, remainder.Area, MathUtil.EPS);
+            Assert.AreEqual(2f, remainder.Area, MathUtil.EPS);
         }
 
         [Test]
         public void UnionSquareFromRectCollinearTest1()
         {
             var remainder = m_union.Union(new List<Polygon2D> {m_2by1rect, m_unitSquare});
-            Assert.AreEqual(1f, remainder.Area, MathUtil.EPS);
+            Assert.AreEqual(2f, remainder.Area, MathUtil.EPS);
         }
 
         [Test]
         public void UnionRectFromSquareCollinearTest2()
         {
             var remainder = m_union.Union(new List<Polygon2D> {m_unitSquare, m_1by2rect});
-            Assert.AreEqual(0f, remainder.Area, MathUtil.EPS);
+            Assert.AreEqual(2f, remainder.Area, MathUtil.EPS);
         }
 
         [Test]
         public void UnionSquareFromRectCollinearTest2()
         {
             var remainder = m_union.Union(new List<Polygon2D> {m_1by2rect, m_unitSquare});
-            Assert.AreEqual(1f, remainder.Area, MathUtil.EPS);
+            Assert.AreEqual(2f, remainder.Area, MathUtil.EPS);
         }
 
         [Test]
         public void UnionRectFromRectCollinearTest1()
         {
             var remainder = m_union.Union(new List<Polygon2D> {m_1by2rect, m_2by1rect});
-            Assert.AreEqual(1f, remainder.Area, MathUtil.EPS);
+            Assert.AreEqual(3f, remainder.Area, MathUtil.EPS);
         }
 
         [Test]
         public void UnionRectFromRectCollinearTest2()
         {
             var remainder = m_union.Union(new List<Polygon2D> {m_2by1rect, m_1by2rect});
-            Assert.AreEqual(1f, remainder.Area, MathUtil.EPS);
+            Assert.AreEqual(3f, remainder.Area, MathUtil.EPS);
         }
 
         [Test]
@@ -135,10 +135,10 @@
             var square = new Polygon2D(squareVertices);
 
             var unionResult = m_union.Union(new List<Polygon2D> {square, horizontalRect});
-            Assert.AreEqual(1f, unionResult.Area, MathUtil.EPS);
+            Assert.AreEqual(3f, unionResult.Area, MathUtil.EPS);
 
             unionResult = m_union.Union(new List<Polygon2D> {horizontalRect, square});
-            Assert.AreEqual(2f, unionResult.Area, MathUtil.EPS);
+            Assert.AreEqual(3f, unionResult.Area, MathUtil.EPS);
         }
     }
 }

--- a/unity/Assets/Scripts/Editor/Tests/Algorithms/Polygon/IUnionTests.cs
+++ b/unity/Assets/Scripts/Editor/Tests/Algorithms/Polygon/IUnionTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Util.Algorithms.Polygon.Tests
+﻿using System.Linq;
+
+namespace Util.Algorithms.Polygon.Tests
 {
     using System.Collections.Generic;
     using NUnit.Framework;
@@ -139,6 +141,49 @@
 
             unionResult = m_union.Union(new List<Polygon2D> {horizontalRect, square});
             Assert.AreEqual(3f, unionResult.Area, MathUtil.EPS);
+        }
+
+        [Test]
+        public void UnionSimpleConvexPolygonsTest1()
+        {
+            // Area = 11 * 24 / 2 = 132
+            // Full area is used = 132
+            var triangle1 = new Polygon2D(new List<Vector2>
+            {
+                new Vector2(5, 1), new Vector2(5, 25), new Vector2(16, 1)
+            });
+            // Area = 9 * 5 = 45
+            // Area in union: 45 - 5*5 = 20
+            var rect1 = new Polygon2D(new List<Vector2>
+            {
+                new Vector2(5, 1), new Vector2(10, 1), new Vector2(10, 10), new Vector2(5, 10)
+            });
+            // Area = 5 * 9 = 45
+            // Area in union: 45 - 45 = 0
+            var rect2 = new Polygon2D(new List<Vector2>
+            {
+                new Vector2(0, 10), new Vector2(9, 10), new Vector2(9, 15), new Vector2(0, 15)
+            });
+            // Area = 87.5
+            // Full area is used = 87.5
+            var polygon1 = new Polygon2D(new List<Vector2>
+            {
+                new Vector2(15, 15), new Vector2(20, 15), new Vector2(20, 30), new Vector2(10, 20)
+            });
+            // Area = 5 * 15 = 75
+            // Area in union: 75 - 5*5/2 = 62.5
+            var rect3 = new Polygon2D(new List<Vector2>
+            {
+                new Vector2(15, 15), new Vector2(20, 15), new Vector2(20, 30), new Vector2(15, 30)
+            });
+
+            var polygon2Ds = new List<Polygon2D> {triangle1, rect1, rect2, polygon1, rect3};
+
+            var sumResult = polygon2Ds.Sum(p => p.Area);
+            Assert.AreEqual(384.5f, sumResult, MathUtil.EPS);
+
+            var unionResult = m_union.Union(polygon2Ds);
+            Assert.AreEqual(302f, unionResult.Area, MathUtil.EPS);
         }
     }
 }

--- a/unity/Assets/Scripts/Editor/Tests/Algorithms/Polygon/IUnionTests.cs
+++ b/unity/Assets/Scripts/Editor/Tests/Algorithms/Polygon/IUnionTests.cs
@@ -1,0 +1,144 @@
+﻿namespace Util.Algorithms.Polygon.Tests
+{
+    using System.Collections.Generic;
+    using NUnit.Framework;
+    using UnityEngine;
+    using Util.Geometry.Polygon;
+    using Math;
+
+    [TestFixture(typeof(UnionNaive))]
+    [TestFixture(typeof(UnionPlaneSweep))]
+    public class IUnionTests<TUnion> where TUnion : IUnion, new()
+    {
+        private TUnion m_union;
+
+        private readonly List<Vector2> m_horizontalRectVertices;
+        private readonly List<Vector2> m_verticalRectVertices;
+        private readonly Polygon2D m_horizontalRect;
+        private readonly Polygon2D m_verticalRect;
+
+        private readonly List<Vector2> m_2by1RectVertices;
+        private readonly List<Vector2> m_1by2RectVertices;
+        private readonly List<Vector2> m_unitSquareVertices;
+
+        private readonly Polygon2D m_2by1rect;
+        private readonly Polygon2D m_1by2rect;
+        private readonly Polygon2D m_unitSquare;
+
+        public IUnionTests()
+        {
+            m_horizontalRectVertices = new List<Vector2>
+            {
+                new Vector2(-2, 1), new Vector2(2, 1), new Vector2(2, -1), new Vector2(-2, -1)
+            };
+            m_verticalRectVertices = new List<Vector2>
+            {
+                new Vector2(-1, 2), new Vector2(1, 2), new Vector2(1, 0), new Vector2(-1, 0)
+            };
+
+            m_horizontalRect = new Polygon2D(m_horizontalRectVertices);
+            m_verticalRect = new Polygon2D(m_verticalRectVertices);
+
+            m_2by1RectVertices = new List<Vector2>
+            {
+                new Vector2(0, 1), new Vector2(2, 1), new Vector2(2, 0), new Vector2(0, 0)
+            };
+            m_1by2RectVertices = new List<Vector2>
+            {
+                new Vector2(0, 2), new Vector2(1, 2), new Vector2(1, 0), new Vector2(0, 0)
+            };
+            m_unitSquareVertices = new List<Vector2>
+            {
+                new Vector2(0, 1), new Vector2(1, 1), new Vector2(1, 0), new Vector2(0, 0)
+            };
+
+            m_2by1rect = new Polygon2D(m_2by1RectVertices);
+            m_1by2rect = new Polygon2D(m_1by2RectVertices);
+            m_unitSquare = new Polygon2D(m_unitSquareVertices);
+        }
+
+        [SetUp]
+        public void CreateUnion()
+        {
+            m_union = new TUnion();
+        }
+
+        [Test]
+        public void UnionTest1()
+        {
+            var cutout = m_union.Union(new List<Polygon2D> {m_verticalRect, m_horizontalRect});
+            Assert.AreEqual(2f, cutout.Area, MathUtil.EPS);
+        }
+
+        [Test]
+        public void UnionTest2()
+        {
+            var cutout = m_union.Union(new List<Polygon2D> {m_horizontalRect, m_verticalRect});
+            Assert.AreEqual(6f, cutout.Area, MathUtil.EPS);
+        }
+
+        [Test]
+        public void UnionRectFromSquareCollinearTest1()
+        {
+            var remainder = m_union.Union(new List<Polygon2D> {m_unitSquare, m_2by1rect});
+            Assert.AreEqual(0f, remainder.Area, MathUtil.EPS);
+        }
+
+        [Test]
+        public void UnionSquareFromRectCollinearTest1()
+        {
+            var remainder = m_union.Union(new List<Polygon2D> {m_2by1rect, m_unitSquare});
+            Assert.AreEqual(1f, remainder.Area, MathUtil.EPS);
+        }
+
+        [Test]
+        public void UnionRectFromSquareCollinearTest2()
+        {
+            var remainder = m_union.Union(new List<Polygon2D> {m_unitSquare, m_1by2rect});
+            Assert.AreEqual(0f, remainder.Area, MathUtil.EPS);
+        }
+
+        [Test]
+        public void UnionSquareFromRectCollinearTest2()
+        {
+            var remainder = m_union.Union(new List<Polygon2D> {m_1by2rect, m_unitSquare});
+            Assert.AreEqual(1f, remainder.Area, MathUtil.EPS);
+        }
+
+        [Test]
+        public void UnionRectFromRectCollinearTest1()
+        {
+            var remainder = m_union.Union(new List<Polygon2D> {m_1by2rect, m_2by1rect});
+            Assert.AreEqual(1f, remainder.Area, MathUtil.EPS);
+        }
+
+        [Test]
+        public void UnionRectFromRectCollinearTest2()
+        {
+            var remainder = m_union.Union(new List<Polygon2D> {m_2by1rect, m_1by2rect});
+            Assert.AreEqual(1f, remainder.Area, MathUtil.EPS);
+        }
+
+        [Test]
+        public void UnionNonIntersectingTest()
+        {
+            var horizontalRectVertices = new List<Vector2>
+            {
+                new Vector2(0, 0), new Vector2(2, 0), new Vector2(2, -1), new Vector2(0, -1)
+            };
+            var squareVertices = new List<Vector2>
+            {
+                new Vector2(10, 10), new Vector2(11, 10), new Vector2(11, 9), new Vector2(10, 9)
+            };
+
+            var horizontalRect = new Polygon2D(horizontalRectVertices);
+            var square = new Polygon2D(squareVertices);
+
+            var unionResult = m_union.Union(new List<Polygon2D> {square, horizontalRect});
+            Assert.AreEqual(1f, unionResult.Area, MathUtil.EPS);
+
+            unionResult = m_union.Union(new List<Polygon2D> {horizontalRect, square});
+            Assert.AreEqual(2f, unionResult.Area, MathUtil.EPS);
+        }
+    }
+}

--- a/unity/Assets/Scripts/Editor/Tests/Algorithms/Polygon/IUnionTests.cs.meta
+++ b/unity/Assets/Scripts/Editor/Tests/Algorithms/Polygon/IUnionTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 825cab3ce0444697974a4bb5099a065e
+timeCreated: 1574843370

--- a/unity/Assets/Scripts/Util/Algorithms/Polygon/IUnion.cs
+++ b/unity/Assets/Scripts/Util/Algorithms/Polygon/IUnion.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Util.Geometry;
-using Util.Geometry.Polygon;
-
-namespace Util.Algorithms.Polygon
+﻿namespace Util.Algorithms.Polygon
 {
+    using System.Collections.Generic;
+    using Util.Geometry.Polygon;
+    
     /// <summary>
     /// This interface defines methods that can be used to calculate the union
     /// of polygons
@@ -21,7 +17,6 @@ namespace Util.Algorithms.Polygon
         /// </param>
         /// <returns>A new polygon which is the union of the polygons defined in
         /// <paramref name="polygons"/></returns>
-        IPolygon2D Union(ICollection<IPolygon2D> polygons);
-
+        IPolygon2D Union(ICollection<Polygon2D> polygons);
     }
 }

--- a/unity/Assets/Scripts/Util/Algorithms/Polygon/UnionNaive.cs
+++ b/unity/Assets/Scripts/Util/Algorithms/Polygon/UnionNaive.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Util.Geometry.Polygon;
-
-namespace Util.Algorithms.Polygon
+﻿namespace Util.Algorithms.Polygon
 {
-    //Will be implemented by Koen and Gijs
+    using System.Collections.Generic;
+    using System.Linq;
+    using Util.Geometry.Polygon;
 
     /// <summary>
     /// Implements the <see cref="Union"/> method by using a naive approach
@@ -14,9 +10,22 @@ namespace Util.Algorithms.Polygon
     public class UnionNaive : IUnion
     {
         /// <inheritdoc />
-        public IPolygon2D Union(ICollection<IPolygon2D> polygons)
+        public IPolygon2D Union(ICollection<Polygon2D> polygons)
         {
-            throw new NotImplementedException();
+            if (polygons.Count <= 0) return new MultiPolygon2D();
+
+            // create multi polygon of polygons
+            var visiblePolygon = new MultiPolygon2D(polygons.First());
+
+            // add all polygons, cutting out the overlap
+            foreach (Polygon2D polygon in polygons.Skip(1))
+            {
+                visiblePolygon = Clipper.CutOut(visiblePolygon, polygon);
+                visiblePolygon.AddPolygon(polygon);
+            }
+
+            // return complete polygon
+            return visiblePolygon;
         }
     }
 }

--- a/unity/Assets/Scripts/Util/Algorithms/Polygon/UnionPlaneSweep.cs
+++ b/unity/Assets/Scripts/Util/Algorithms/Polygon/UnionPlaneSweep.cs
@@ -15,7 +15,7 @@ namespace Util.Algorithms.Polygon
     public class UnionPlaneSweep: IUnion
     {
         /// <inheritdoc />
-        public IPolygon2D Union(ICollection<IPolygon2D> polygons)
+        public IPolygon2D Union(ICollection<Polygon2D> polygons)
         {
             throw new NotImplementedException();
         }

--- a/unity/ProjectSettings/EditorSettings.asset
+++ b/unity/ProjectSettings/EditorSettings.asset
@@ -14,7 +14,7 @@ EditorSettings:
   m_EtcTextureFastCompressor: 2
   m_EtcTextureNormalCompressor: 2
   m_EtcTextureBestCompressor: 5
-  m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd
+  m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd;asmdef
   m_ProjectGenerationRootNamespace: 
   m_UserGeneratedProjectSuffix: 
   m_CollabEditorSettings:


### PR DESCRIPTION
This is basically just the setup for using `IUnion` in all places and copying some tests from the `CutOut`.

The tests which are failing are failing because the cutout implementation is not correct. I've copied the following test cases:

![texstudio_2019-11-28_09-47-38](https://user-images.githubusercontent.com/1112623/69791175-3e9d9b80-11c4-11ea-8170-f8f6fd066287.png)

![texstudio_2019-11-28_09-47-49](https://user-images.githubusercontent.com/1112623/69791181-42312280-11c4-11ea-9dbd-1c553cf7b7e9.png)

![texstudio_2019-11-28_09-48-01](https://user-images.githubusercontent.com/1112623/69791186-44937c80-11c4-11ea-9049-7c030034dcfe.png)

![texstudio_2019-11-28_10-02-27](https://user-images.githubusercontent.com/1112623/69792115-36def680-11c6-11ea-8bcb-55d6605b26a9.png)
